### PR TITLE
Fix MANIFEST license path

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
 # Include the license file
-include LICENSE.txt
+include LICENSE


### PR DESCRIPTION
## Summary
- include `LICENSE` in the manifest instead of `LICENSE.txt`
- verified that `python setup.py sdist` includes the license

## Testing
- `pytest -q` *(fails: command not found)*
- `python setup.py sdist`