### PR TITLE
Fix duplicate test name

### DIFF
--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -154,7 +154,7 @@ def test_response_for_ico():
     assert b"test_cookie=cookie_value" in response.headers.get("Set-Cookie")
 
 
-def test_response_for_ico():
+def test_response_for_png():
     headers = {"Custom-Header": "test-value"}
     cookies = {"test_cookie": "cookie_value"}
 


### PR DESCRIPTION
## Summary
- fix duplicate test name by renaming the second `test_response_for_ico` to `test_response_for_png`

## Testing
- `pytest -q` *(fails: pytest not installed)*